### PR TITLE
PR : Update to version 0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@knowledgr/knowledgr-js",
-  "version": "0.7.3",
+  "name": "@nrl-demo/knowledgr-js",
+  "version": "0.7.4",
   "description": "Knowledgr.js the JavaScript API for Knowledgr blockchain",
   "main": "lib/index.js",
   "scripts": {
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/norestlabs/knowledgr-js#readme",
   "dependencies": {
-    "@knowledgr/rpc-auth": "file:../rpc-auth",
+    "@nrl-demo/rpc-auth": "^1.1.1",
     "bigi": "^1.4.2",
     "bluebird": "^3.4.6",
     "browserify-aes": "^1.0.6",
@@ -46,6 +46,7 @@
     "detect-node": "^2.0.3",
     "ecurve": "^1.0.5",
     "lodash": "^4.16.4",
+    "retry": "^0.12.0",
     "secure-random": "^1.1.1",
     "ws": "^3.3.2"
   },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -17,7 +17,7 @@ import {
 } from './transports/http';
 import {
     sign as signRequest
-} from '@knowledgr/rpc-auth';
+} from '@nrl-demo/rpc-auth';
 
 class Steem extends EventEmitter {
     constructor(options = {}) {

--- a/src/api/transports/base.js
+++ b/src/api/transports/base.js
@@ -27,7 +27,6 @@ export default class Transport extends EventEmitter {
   send() {}
   start() {}
   stop() {}
-
 }
 
 Promise.promisifyAll(Transport.prototype);

--- a/src/api/transports/http.js
+++ b/src/api/transports/http.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import newDebug from 'debug';
+import retry from 'retry';
 import Transport from './base';
 
 const debug = newDebug('steem:http');
@@ -13,9 +14,20 @@ class RPCError extends Error {
   }
 }
 
-export function jsonRpc(uri, {method, id, params}) {
+/**
+ * Makes a JSON-RPC request using `fetch` or a user-provided `fetchMethod`.
+ *
+ * @param {string} uri - The URI to the JSON-RPC endpoint.
+ * @param {string} options.method - The remote JSON-RPC method to call.
+ * @param {string} options.id - ID for the request, for matching to a response.
+ * @param {*} options.params  - The params for the remote method.
+ * @param {function} [options.fetchMethod=fetch] - A function with the same
+ * signature as `fetch`, which can be used to make the network request, or for
+ * stubbing in tests.
+ */
+export function jsonRpc(uri, {method, id, params, fetchMethod=fetch}) {
   const payload = {id, jsonrpc: '2.0', method, params};
-  return fetch(uri, {
+  return fetchMethod(uri, {
     body: JSON.stringify(payload),
     method: 'post',
     mode: 'cors',
@@ -42,12 +54,56 @@ export function jsonRpc(uri, {method, id, params}) {
 export default class HttpTransport extends Transport {
   send(api, data, callback) {
     if (this.options.useAppbaseApi) {
-        api = 'condenser_api';
+      api = 'condenser_api';
     }
     debug('Steem::send', api, data);
     const id = data.id || this.id++;
     const params = [api, data.method, data.params];
-    jsonRpc(this.options.uri, {method: 'call', id, params})
-      .then(res => { callback(null, res) }, err => { callback(err) })
+    const retriable = this.retriable(api, data);
+    const fetchMethod = this.options.fetchMethod;
+    if (retriable) {
+      retriable.attempt((currentAttempt) => {
+        jsonRpc(this.options.uri, { method: 'call', id, params, fetchMethod }).then(
+          res => { callback(null, res); },
+          err => {
+            if (retriable.retry(err)) {
+              return;
+            }
+            callback(retriable.mainError());
+          }
+        );
+      });
+    } else {
+      jsonRpc(this.options.uri, { method: 'call', id, params, fetchMethod }).then(
+        res => { callback(null, res); },
+        err => { callback(err); }
+      );
+    }
+  }
+
+  get nonRetriableOperations() {
+    return this.options.nonRetriableOperations || [
+      'broadcast_transaction',
+      'broadcast_transaction_with_callback',
+      'broadcast_transaction_synchronous',
+      'broadcast_block',
+    ];
+  }
+
+  // An object which can be used to track retries.
+  retriable(api, data) {
+    if (this.nonRetriableOperations.some((o) => o === data.method)) {
+      // Do not retry if the operation is non-retriable.
+      return null;
+    } else if (Object(this.options.retry) === this.options.retry) {
+      // If `this.options.retry` is a map of options, pass those to operation.
+      return retry.operation(this.options.retry);
+    } else if (this.options.retry) {
+      // If `this.options.retry` is `true`, use default options.
+      return retry.operation();
+    } else {
+      // Otherwise, don't retry.
+      return null;
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,8 +2,10 @@
 # yarn lockfile v1
 
 
-"@knowledgr/rpc-auth@file:../rpc-auth":
+"@nrl-demo/rpc-auth@^1.1.1":
   version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@nrl-demo/rpc-auth/-/rpc-auth-1.1.1.tgz#b3e69343e97ab50059aa91502ddc81a35a674771"
+  integrity sha512-i1FPgoXMO3et2zOgMjSR3V6L9Awz2jzFlO39ZLTTxQ9aAjhKpYoxwO8uogldojXXMjOE/mb4Iz3mv6gbuDevBg==
   dependencies:
     "@steemit/libcrypto" "^1.0.1"
 
@@ -2774,6 +2776,11 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 right-align@^0.1.1:
   version "0.1.3"


### PR DESCRIPTION
Merge latest update - to `Version 0.7.4`.

- Test result
```
  steem.auth: Crypto
    ✓ sign (2487ms)

  steem.auth: derives
    ✓ child from public
    ✓ child from private (69ms)

  steem.auth: key_formats
    ✓ Calcualtes public key from private key (38ms)
    ✓ Create BTS short address
    ✓ Blockchain Address
    ✓ BTS public key import / export
    ✓ PTS
    ✓ To WIF
    ✓ From WIF
    ✓ Calc public key
    ✓ BTS/BTC uncompressed
    ✓ BTS/BTC compressed
    ✓ BTS/PTS uncompressed
    ✓ BTS/PTS compressed
    ✓ null hex to pubkey
    ✓ null pubkey to hex

  steem.auth: all types
    ✓ from object
    ✓ to object
    ✓ to buffer
    ✓ from buffer
    ✓ template
{ uint8: 255,
  uint16: 65535,
  uint32: 4294967295,
  int16: 30000,
  int64: '9223372036854775807',
  uint64: '9223372036854775807',
  string: '‘Quote’',
  string_binary: '\u0001',
  bytes: 'ff',
  bool: true,
  array: [ 1, 2 ],
  fixed_array: [ 0, 1 ],
  protocol_id_type: '1.1.1',
  object_id_type: '1.1.1',
  static_variant: [ [ 'transfer', [Object] ], [ 'price', [Object] ] ],
  map: [ [ 2, 1 ], [ 4, 3 ] ],
  set: [ 1, 2 ],
  public_key: 'STM859gxfnXyUriMgUeThh1fWv3oqcpLFyHa3TfFYC4PK2HqhToVM',
  address: 'STM664KmHxSuQyDsfwo4WEJvWpzg1QKdg67S',
  time_optional: undefined,
  time_point_sec1: '2019-01-17T15:52:08',
  time_point_sec2: '2019-01-17T15:52:08',
  time_point_sec3: '2017-02-16T20:27:12' }
    ✓ visual check

  steem.api:
    setOptions
      ✓ works
    getFollowers
      getting ned's followers
        ✓ works (1278ms)
        ✓ the startFollower parameter has an impact on the result (2156ms)
        ✓ clears listeners
    getContent
      getting a random post
        ✓ works (1103ms)
        ✓ clears listeners
    streamBlockNumber
      ✓ streams steem transactions (6241ms)
    streamBlock
      ✓ streams steem blocks (7337ms)
    streamTransactions
      ✓ streams steem transactions (2165ms)
    streamOperations
      ✓ streams steem operations (2172ms)
    useApiOptions
      ✓ works ok with the prod instances (1077ms)
    with retry
      ✓ works by default
      ✓ does not retry by default
      ✓ works with retry passed as a boolean
      ✓ retries with retry passed as a boolean (1004ms)
      ✓ works with retry passed as an object
      ✓ retries with retry passed as an object
      - does not retry non-retriable operations

  steem.broadcast:
    ✓ exists
    ✓ has generated methods
    ✓ has backing methods
    ✓ has promise methods
    patching transaction with default global properties
      ✓ works (2160ms)
    downvoting
      ✓ works (6479ms)
    voting
      ✓ works (7056ms)
      ✓ works with callbacks (6994ms)
    customJson
      ✓ works (6948ms)
    writeOperations
      ✓ receives a properly formatted error response (3536ms)

  steem.broadcast:
    comment with options
      ✓ works (6424ms)

  steem.hf20-accounts:
    ✓ has generated methods
    ✓ has promise methods
    claimAccount
      ✓ signs and verifies auth (1068ms)
      - claims and creates account

  steem.auth: memo
    ✓ plain text
    ✓ encryption obj params (199ms)
    ✓ encryption string params (133ms)
    ✓ known encryption (80ms)

  steem.auth: Number utils
    ✓ to implied decimal
    ✓ from implied decimal

  steem.auth: operation test
    ✓ templates
    ✓ account_create

  steem.auth: types
    ✓ vote_id
    ✓ set sort
    ✓ string sort
    ✓ map sort
    ✓ public_key sort
    ✓ type_id sort
    ✓ precision number strings
    ✓ precision number long


  70 passing (1m)
  2 pending
```