### PR TITLE
PR : issue-43 Add get_state api unit test

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -11,7 +11,7 @@ describe('steem.api:', function () {
   describe('setOptions', () => {
     it('works', () => {
       let url = steem.config.get('uri');
-      if(! url) url = steem.config.get('websocket');
+      if (!url) url = steem.config.get('websocket');
       steem.api.setOptions({ url: url, useAppbaseApi: true });
     });
   });
@@ -21,6 +21,31 @@ describe('steem.api:', function () {
       it('works', async () => {
         const result = await steem.api.getAccountsAsync(['test1']);
         result.should.be.an.Array()
+      });
+
+      it('clears listeners', async () => {
+        steem.api.listeners('message').should.have.lengthOf(0);
+      });
+    });
+  });
+
+  describe('getState', () => {
+    describe('getting state', () => {
+      it('works', async () => {
+        const result = await steem.api.getStateAsync('');
+        should.exist(result);
+        result.should.have.properties([
+          'current_route',
+          'props',
+          'tag_idx',
+          'tags',
+          'content',
+          'accounts',
+          'witnesses',
+          'discussion_idx',
+          'witness_schedule',
+          'error',
+        ]);
       });
 
       it('clears listeners', async () => {
@@ -163,7 +188,7 @@ describe('steem.api:', function () {
   */
 
   describe('useApiOptions', () => {
-    it('works ok with the prod instances', async() => {
+    it('works ok with the prod instances', async () => {
       steem.api.setOptions({ useAppbaseApi: true, url: steem.config.get('uri') });
 
       const result = await steem.api.getContentAsync('yamadapc', 'test-1-2-3-4-5-6-7-9');
@@ -179,7 +204,7 @@ describe('steem.api:', function () {
       steemApi = new api.Steem({});
     });
 
-    it('works by default', async function() {
+    it('works by default', async function () {
       let attempts = 0;
       steemApi.setOptions({
         url: 'http://knowledgrd.mousebelt.com:8091',
@@ -201,7 +226,7 @@ describe('steem.api:', function () {
       assert.deepEqual(result, ['ned']);
     });
 
-    it('does not retry by default', async() => {
+    it('does not retry by default', async () => {
       let attempts = 0;
       steemApi.setOptions({
         url: 'http://knowledgrd.mousebelt.com:8091',
@@ -222,7 +247,7 @@ describe('steem.api:', function () {
       assert.equal(errored, true);
     });
 
-    it('works with retry passed as a boolean', async() => {
+    it('works with retry passed as a boolean', async () => {
       let attempts = 0;
       steemApi.setOptions({
         url: 'http://knowledgrd.mousebelt.com:8091',
@@ -245,7 +270,7 @@ describe('steem.api:', function () {
       assert.deepEqual(result, ['ned']);
     });
 
-    it('retries with retry passed as a boolean', async() => {
+    it('retries with retry passed as a boolean', async () => {
       let attempts = 0;
       steemApi.setOptions({
         url: 'http://knowledgrd.mousebelt.com:8091',
@@ -280,7 +305,7 @@ describe('steem.api:', function () {
       assert.deepEqual(result, ['ned']);
     });
 
-    it('works with retry passed as an object', async() => {
+    it('works with retry passed as an object', async () => {
       steemApi.setOptions({
         url: 'http://knowledgrd.mousebelt.com:8091',
         retry: {
@@ -304,7 +329,7 @@ describe('steem.api:', function () {
       assert.deepEqual(result, ['ned']);
     });
 
-    it('retries with retry passed as an object', async() => {
+    it('retries with retry passed as an object', async () => {
       let attempts = 0;
       steemApi.setOptions({
         url: 'http://knowledgrd.mousebelt.com:8091',


### PR DESCRIPTION
Close #43 

- rpc result
```
{
        "current_route": "",
        "props": {
            "head_block_number": 186003,
            "head_block_id": "0002d6931087c8f079d465565677d5dd86f9b2bd",
            "time": "2019-01-24T06:40:42",
            "current_witness": "initminer",
            "total_pow": "18446744073709551615",
            "num_pow_witnesses": 0,
            "virtual_supply": "251304070.320 KNLG",
            "current_supply": "251304070.320 KNLG",
            "confidential_supply": "0.000 KNLG",
            "total_reward_fund_knowledgr": "0.000 KNLG",
            "total_reward_shares2": "0",
            "maximum_block_size": 131072,
            "current_aslot": 29825614,
            "recent_slots_filled": "340282366920938463463374607431768211455",
            "participation_count": 128,
            "last_irreversible_block_num": 185982,
            "vote_power_reserve_rate": 10,
            "delegation_return_period": 432000,
            "reverse_auction_seconds": 900,
            "num_of_accounts": 10
        },
        "tag_idx": {
            "trending": []
        },
        "tags": {},
        "content": {},
        "accounts": {},
        "witnesses": {},
        "discussion_idx": {
            "": {
                "category": "",
                "trending": [],
                "payout": [],
                "payout_comments": [],
                "trending30": [],
                "updated": [],
                "created": [],
                "responses": [],
                "active": [],
                "votes": [],
                "maturing": [],
                "best": [],
                "hot": [],
                "promoted": [],
                "cashout": []
            }
        },
        "witness_schedule": {
            "id": 0,
            "current_virtual_time": "0",
            "next_shuffle_block_num": 185998,
            "current_shuffled_witnesses": [
                "initminer",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                "",
                ""
            ],
            "num_scheduled_witnesses": 1,
            "elected_weight": 1,
            "timeshare_weight": 5,
            "miner_weight": 1,
            "witness_pay_normalization_factor": 1,
            "median_props": {
                "account_creation_fee": "0.030 KNLG",
                "maximum_block_size": 131072,
                "account_subsidy_budget": 797,
                "account_subsidy_decay": 347321
            },
            "majority_version": "0.0.0",
            "max_voted_witnesses": 20,
            "max_miner_witnesses": 0,
            "max_runner_witnesses": 1,
            "hardfork_required_witnesses": 17,
            "account_subsidy_rd": {
                "resource_unit": 10000,
                "budget_per_time_unit": 797,
                "pool_eq": 157691079,
                "max_pool_size": 157691079,
                "decay_params": {
                    "decay_per_time_unit": 347321,
                    "decay_per_time_unit_denom_shift": 36
                },
                "min_decay": 0
            },
            "account_subsidy_witness_rd": {
                "resource_unit": 10000,
                "budget_per_time_unit": 996,
                "pool_eq": 9384019,
                "max_pool_size": 9384019,
                "decay_params": {
                    "decay_per_time_unit": 7293741,
                    "decay_per_time_unit_denom_shift": 36
                },
                "min_decay": 896
            },
            "min_witness_account_subsidy_decay": 0
        },
        "error": ""
    }
```

- test result
```
    getState
      getting state
        ✓ works (638ms)
        ✓ clears listeners
```